### PR TITLE
feat(pv-editor): add event extension functionality to extend associat…

### DIFF
--- a/NOUVEAUTES.md
+++ b/NOUVEAUTES.md
@@ -4,7 +4,9 @@ Ce fichier garde une vue d ensemble courte des evolutions recentes, avec un angl
 
 ## 2026-09-06
 
-- Depuis les onglets d applications d un PV, les fiches de detail s ouvrent maintenant dans les sous-drawers internes de l editeur sans modifier le hash global. Leur entete et leur bouton Fermer restent disponibles, un clic sur l arriere-plan les referme, et les panneaux Projet et Indicateur ont la meme largeur limitee avec une ouverture animee depuis la droite.
+- Dans l editeur de PV, un bouton `+` a cote de l horaire permet aux personnes autorisees a modifier l evenement de prolonger la reunion de 5, 10, 15 ou 30 minutes. La nouvelle heure de fin et le minuteur sont mis a jour immediatement, les autres editeurs se resynchronisent, et les notifications de changement d horaire habituelles sont envoyees.
+- Depuis les onglets d applications d un PV, les fiches de detail s ouvrent maintenant dans les sous-drawers internes de l editeur sans modifier le hash global. Les applications remplacent uniquement la partie droite de l editeur afin de garder l ordre du jour, le minuteur et la barre de redimensionnement visibles. Tous les drawers internes des applications, notamment Documents, utilisent automatiquement une largeur limitee et une ouverture animee depuis la droite ; leur entete et leur bouton Fermer restent disponibles et un clic sur l arriere-plan les referme.
+- Dans l onglet Documents d une reunion, seuls les PV valides peuvent maintenant etre ouverts comme des documents ordinaires. Les PV en preparation, en cours ou en validation restent visibles pour le classement, mais leurs cartes ne declenchent plus l editeur d un second PV et ne peuvent donc plus remplacer ou fermer le drawer de la reunion courante.
 
 ## 2026-09-05
 

--- a/class/dbobject/event.class.php
+++ b/class/dbobject/event.class.php
@@ -1061,6 +1061,7 @@ class Event extends DbObject
             }
 
             $document->set('datecreation', \DateTimeImmutable::createFromInterface($endAt));
+            $document->set('datemodification', new \DateTimeImmutable());
             $saveResult = $document->save();
             if (!is_array($saveResult) || ($saveResult['status'] ?? false) !== true) {
                 return [

--- a/omo/api/documents/index.php
+++ b/omo/api/documents/index.php
@@ -391,6 +391,7 @@ $applicationViewPreferences = omoApplicationViewPreferencesGetContext(
     $currentContextHolon instanceof Holon ? $currentContextHolon : null,
     $currentUserId
 );
+$isPvApplicationTab = !empty($applicationViewPreferences['isPvApplicationTab']);
 $documentScope = omoApiNormalizeContextScope(
     omoApplicationViewPreferencesGetInitialValue($applicationViewPreferences, 'document_scope', 'scope', 'contextual'),
     $availableDocumentScopes
@@ -620,6 +621,10 @@ foreach ($documents as $document) {
     $pvPreparationUrl = $canOpenPvEditor
         ? $document->buildPvEditorUrl($currentOrganizationId)
         : '';
+    $isPvDocument = $document->isPvDocument();
+    $isPvValidated = $isPvDocument && $document->isPvValidated();
+    $canOpenInPvApplicationTab = !$isPvDocument || $isPvValidated;
+    $canOpenInCurrentView = !$isPvApplicationTab || $canOpenInPvApplicationTab;
     $isFolder = $document->isFolder();
     $isExternalLink = $document->isExternalLink();
     $canShareDocument = !$isFolder && $document->supportsHtmlContent();
@@ -641,6 +646,8 @@ foreach ($documents as $document) {
         'title' => $documentTitle,
         'listTitle' => $listTitle,
         'documentType' => $document->getDocumentType(),
+        'isPvValidated' => $isPvValidated,
+        'canOpenInPvApplicationTab' => $canOpenInPvApplicationTab,
         'storedFileKind' => $document->isUploadedFile() ? $document->getStoredFileKind() : '',
         'isMissingUploadedFile' => $document->hasMissingUploadedFile(),
         'canExportPdf' => $document->isPvDocument(),
@@ -682,13 +689,13 @@ foreach ($documents as $document) {
             && (int)$document->get('IDevent') <= 0
             && !isset($documentListMetadata['documentsWithChildren'][$documentId]),
         'canEdit' => $document->isPvDocument()
-            ? $canOpenPvEditor
+            ? ($canOpenInCurrentView && $canOpenPvEditor)
             : (
                 $canManageDocument
                  || (!$document->isEtherpadDocument() && !$document->isEthercalcDocument() && !$document->isWhiteboardDocument() && $document->canEditInOrganizationContextWithVisibilityRules($documentOrganizationId, $currentUserId, $visibilityRule, $editVisibilityRule, $documentViewerContext))
             ),
         'editUrl' => $document->isPvDocument()
-            ? $pvPreparationUrl
+            ? ($canOpenInCurrentView ? $pvPreparationUrl : '')
             : ('/omo/api/documents/create.php?id=' . $documentId
                 . ($documentOrganizationId > 0 ? '&oid=' . $documentOrganizationId : '')
                 . ($documentHolonId > 0 ? '&cid=' . $documentHolonId : '')),
@@ -758,6 +765,11 @@ if ($initialOpenDocumentId > 0) {
             'title' => $requestedCanOpenDirectly ? (string)$requestedOpenDocument->get('title') : '',
             'fullDateLabel' => $requestedCanOpenDirectly ? $formatDate($requestedResolvedCreatedAt, true) : '',
             'documentType' => $requestedCanOpenDirectly ? $requestedOpenDocument->getDocumentType() : '',
+            'isPvValidated' => $requestedCanOpenDirectly
+                && $requestedOpenDocument->isPvDocument()
+                && $requestedOpenDocument->isPvValidated(),
+            'canOpenInPvApplicationTab' => !$requestedOpenDocument->isPvDocument()
+                || ($requestedCanOpenDirectly && $requestedOpenDocument->isPvValidated()),
             'isFolder' => $requestedOpenDocument->isFolder(),
             'openInNewWindow' => false,
             'externalUrl' => '',
@@ -766,7 +778,10 @@ if ($initialOpenDocumentId > 0) {
                 : '',
             'hasUpcomingPvEvent' => $requestedCanOpenDirectly ? $requestedOpenDocument->hasUpcomingAssociatedEvent() : false,
             'canEdit' => $requestedOpenDocument->isPvDocument()
-                ? $requestedCanOpenPvEditor
+                ? (
+                    (!$isPvApplicationTab || $requestedOpenDocument->isPvValidated())
+                    && $requestedCanOpenPvEditor
+                )
                 : (
                     $requestedCanView
                     && (
@@ -778,7 +793,11 @@ if ($initialOpenDocumentId > 0) {
                     )
                 ),
             'editUrl' => $requestedOpenDocument->isPvDocument()
-                ? ($requestedCanOpenPvEditor ? $requestedOpenDocument->buildPvEditorUrl($currentOrganizationId) : '')
+                ? (
+                    (!$isPvApplicationTab || $requestedOpenDocument->isPvValidated()) && $requestedCanOpenPvEditor
+                        ? $requestedOpenDocument->buildPvEditorUrl($currentOrganizationId)
+                        : ''
+                )
                 : ($requestedCanView
                     ? '/omo/api/documents/create.php?id=' . $requestedDocumentId
                         . '&oid=' . $currentOrganizationId
@@ -796,6 +815,8 @@ if ($initialOpenDocumentId > 0) {
             'title' => '',
             'fullDateLabel' => '',
             'documentType' => '',
+            'isPvValidated' => false,
+            'canOpenInPvApplicationTab' => false,
             'isFolder' => false,
             'openInNewWindow' => false,
             'externalUrl' => '',
@@ -974,11 +995,11 @@ if (!is_string($documentsPayload)) {
                         <h3 class="omo-panel-group__title generic-file-list__group-title"><?= $escape($entry['groupLabel']) ?></h3>
                         <div class="omo-documents__list omo-panel-view__body_content">
                 <?php endif; ?>
+                            <?php $entryCanOpen = !$isPvApplicationTab || !empty($entry['canOpenInPvApplicationTab']); ?>
                             <article class="omo-documents__item-shell generic-file-list__item-shell<?= !empty($entry['isMissingUploadedFile']) ? ' omo-documents__item-shell--missing-upload' : '' ?>">
                                 <div
-                                    class="omo-documents__item omo-card omo-card--interactive"
-                                    role="button"
-                                    tabindex="0"
+                                    class="omo-documents__item omo-card<?= $entryCanOpen ? ' omo-card--interactive' : ' omo-documents__item--unavailable' ?>"
+                                    <?= $entryCanOpen ? 'role="button" tabindex="0"' : 'aria-disabled="true"' ?>
                                     data-omo-document-id="<?= $escape($entry['id']) ?>"
                                     data-omo-document-href="<?= $escape($entry['href']) ?>"
                                     data-omo-document-context-url="<?= $escape($entry['contextUrl']) ?>"
@@ -986,6 +1007,7 @@ if (!is_string($documentsPayload)) {
                                     data-omo-document-open-in-new-window="<?= !empty($entry['openInNewWindow']) ? '1' : '0' ?>"
                                     data-omo-document-type="<?= $escape($entry['documentType']) ?>"
                                     data-omo-document-pv-editor-url="<?= $escape($entry['pvPreparationUrl'] ?? '') ?>"
+                                    data-omo-document-can-open-in-pv-tab="<?= !empty($entry['canOpenInPvApplicationTab']) ? '1' : '0' ?>"
                                     data-omo-document-title="<?= $escape($entry['title']) ?>"
                                     data-omo-document-full-date="<?= $escape($entry['fullDateLabel']) ?>"
                                 >
@@ -1092,7 +1114,7 @@ if (!is_string($documentsPayload)) {
             <?php endif; ?>
         </div>
 
-            <div class="omo-overlay-drawer omo-documents__detail-drawer" data-omo-document-detail-drawer hidden>
+            <div class="omo-overlay-drawer<?= !empty($applicationViewPreferences['isPvApplicationTab']) ? ' omo-overlay-drawer--detail-panel' : '' ?> omo-documents__detail-drawer" data-omo-document-detail-drawer hidden>
                 <div class="omo-overlay-drawer__backdrop" data-omo-document-detail-close></div>
                 <div class="omo-overlay-drawer__panel">
                     <div class="omo-overlay-drawer__header generic-drawer-header">
@@ -1525,6 +1547,11 @@ if (!is_string($documentsPayload)) {
                             }
 
                             const documents = Array.isArray(payload.documents) ? payload.documents.slice() : [];
+                            const isPvApplicationTab = <?= $isPvApplicationTab ? 'true' : 'false' ?>
+                                || (
+                                    typeof window.omoIsPvApplicationTabContext === 'function'
+                                    && window.omoIsPvApplicationTabContext(panel)
+                                );
                             const requestedDocument = payload && payload.requestedDocument && typeof payload.requestedDocument === 'object'
                                 ? payload.requestedDocument
                                 : null;
@@ -1949,6 +1976,7 @@ if (!is_string($documentsPayload)) {
                                     container.setAttribute('data-omo-document-open-in-new-window', documentItem.openInNewWindow ? '1' : '0');
                                     container.setAttribute('data-omo-document-type', documentItem.documentType || '');
                                     container.setAttribute('data-omo-document-pv-editor-url', documentItem.pvPreparationUrl || '');
+                                    container.setAttribute('data-omo-document-can-open-in-pv-tab', documentItem.canOpenInPvApplicationTab ? '1' : '0');
                                     container.setAttribute('data-omo-document-title', documentItem.title || '');
                                     container.setAttribute('data-omo-document-full-date', documentItem.fullDateLabel || '');
                                 }
@@ -2378,7 +2406,12 @@ if (!is_string($documentsPayload)) {
                                 } else {
                                     const link = document.createElement('div');
                                     link.className = 'omo-documents__item omo-card';
-                                    appendDocumentCardContent(link, documentItem, { interactive: true });
+                                    const canOpenDocument = !isPvApplicationTab || documentItem.canOpenInPvApplicationTab === true;
+                                    appendDocumentCardContent(link, documentItem, { interactive: canOpenDocument });
+                                    if (!canOpenDocument) {
+                                        link.classList.add('omo-documents__item--unavailable');
+                                        link.setAttribute('aria-disabled', 'true');
+                                    }
                                     shell.appendChild(link);
                                 }
 
@@ -2454,8 +2487,13 @@ if (!is_string($documentsPayload)) {
                                     return;
                                 }
 
-                                detailDrawer.hidden = false;
+                                if (detailDrawerController && typeof detailDrawerController.open === 'function') {
+                                    detailDrawerController.open();
+                                    return;
+                                }
 
+                                detailDrawer.hidden = false;
+                                void detailDrawer.offsetWidth;
                                 requestAnimationFrame(function () {
                                     detailDrawer.classList.add('is-open');
                                 });
@@ -2742,6 +2780,14 @@ if (!is_string($documentsPayload)) {
 
                             const openDocumentDetail = function (documentItem) {
                                 if (!detailDrawer || !detailBody || !documentItem || !documentItem.id || documentItem.isFolder) {
+                                    return;
+                                }
+
+                                if (
+                                    isPvApplicationTab
+                                    && String(documentItem.documentType || '').trim().toLowerCase() === 'pv'
+                                    && documentItem.canOpenInPvApplicationTab !== true
+                                ) {
                                     return;
                                 }
 
@@ -3635,8 +3681,11 @@ if (!is_string($documentsPayload)) {
 
                                         if (targetMode === 'edit') {
                                             if (
-                                                typeof window.omoPreserveDocumentPvPreparationDrawer !== 'function'
-                                                || !window.omoPreserveDocumentPvPreparationDrawer()
+                                                !isPvApplicationTab
+                                                && (
+                                                    typeof window.omoPreserveDocumentPvPreparationDrawer !== 'function'
+                                                    || !window.omoPreserveDocumentPvPreparationDrawer()
+                                                )
                                             ) {
                                                 if (typeof window.omoCloseDocumentPvPreparationDrawer === 'function') {
                                                     window.omoCloseDocumentPvPreparationDrawer({ force: true });
@@ -3690,8 +3739,11 @@ if (!is_string($documentsPayload)) {
 
                                     window.omoCloseDocumentEditorDrawer({ force: true });
                                     if (
-                                        typeof window.omoPreserveDocumentPvPreparationDrawer !== 'function'
-                                        || !window.omoPreserveDocumentPvPreparationDrawer()
+                                        !isPvApplicationTab
+                                        && (
+                                            typeof window.omoPreserveDocumentPvPreparationDrawer !== 'function'
+                                            || !window.omoPreserveDocumentPvPreparationDrawer()
+                                        )
                                     ) {
                                         if (typeof window.omoCloseDocumentPvPreparationDrawer === 'function') {
                                             window.omoCloseDocumentPvPreparationDrawer({ force: true });
@@ -3960,6 +4012,12 @@ if (!is_string($documentsPayload)) {
                     && window.omoIsPvApplicationTabContext(root);
             }
 
+            function isPvDocumentBlockedInLocalNavigation(documentItem, rootOverride) {
+                return useLocalDrawerNavigation(rootOverride)
+                    && String(documentItem && documentItem.documentType ? documentItem.documentType : '').trim().toLowerCase() === 'pv'
+                    && documentItem.canOpenInPvApplicationTab !== true;
+            }
+
             function buildDocumentsPanelUrl(root) {
                 if (!root) {
                     return '/omo/api/documents/index.php';
@@ -4093,10 +4151,15 @@ if (!is_string($documentsPayload)) {
                     ? getSkeleton('panel')
                     : '<div class="loading"><?= $escape(omoDocumentsScopeT('documents.action.loading')) ?></div>';
 
-                drawer.hidden = false;
-                requestAnimationFrame(function () {
-                    drawer.classList.add('is-open');
-                });
+                if (drawerController && typeof drawerController.open === 'function') {
+                    drawerController.open();
+                } else {
+                    drawer.hidden = false;
+                    void drawer.offsetWidth;
+                    requestAnimationFrame(function () {
+                        drawer.classList.add('is-open');
+                    });
+                }
 
                 fetch(targetUrl, {
                     credentials: 'same-origin',
@@ -4431,12 +4494,17 @@ if (!is_string($documentsPayload)) {
                 }
             };
 
-            window.omoOpenDocumentPvPreparationByPayload = function (documentItem) {
+            window.omoOpenDocumentPvPreparationByPayload = function (documentItem, rootOverride) {
                 const preparationUrl = String(documentItem && documentItem.pvPreparationUrl ? documentItem.pvPreparationUrl : '').trim();
                 const documentId = Number(documentItem && documentItem.id ? documentItem.id : 0);
                 const title = String(documentItem && documentItem.title ? documentItem.title : '').trim();
                 const fullDate = String(documentItem && documentItem.fullDateLabel ? documentItem.fullDateLabel : '').trim();
                 const hasUpcomingPvEvent = !!(documentItem && documentItem.hasUpcomingPvEvent);
+                const documentsRoot = rootOverride instanceof Element ? rootOverride : getDocumentsRoot();
+
+                if (useLocalDrawerNavigation(documentsRoot)) {
+                    return false;
+                }
 
                 if (
                     preparationUrl === ''
@@ -4467,15 +4535,20 @@ if (!is_string($documentsPayload)) {
             };
 
             window.omoOpenDocumentDetailByPayload = function (documentItem, rootOverride) {
+                const root = rootOverride instanceof Element
+                    ? rootOverride
+                    : getDocumentsRoot();
+
+                if (isPvDocumentBlockedInLocalNavigation(documentItem, root)) {
+                    return false;
+                }
+
                 if (documentItem && documentItem.openInNewWindow && documentItem.externalUrl) {
                     if (openExternalDocumentWindow(documentItem)) {
                         return true;
                     }
                 }
 
-                const root = rootOverride instanceof Element
-                    ? rootOverride
-                    : getDocumentsRoot();
                 const drawer = root ? root.querySelector('[data-omo-document-detail-drawer]') : null;
                 const body = drawer ? drawer.querySelector('[data-omo-document-detail-body]') : null;
                 const titleNode = drawer ? drawer.querySelector('[data-omo-document-detail-title]') : null;
@@ -4488,7 +4561,7 @@ if (!is_string($documentsPayload)) {
                     return false;
                 }
 
-                if (!window.omoPreserveDocumentPvPreparationDrawer()) {
+                if (!useLocalDrawerNavigation(root) && !window.omoPreserveDocumentPvPreparationDrawer()) {
                     window.omoCloseDocumentPvPreparationDrawer({ force: true });
                 }
 
@@ -4557,20 +4630,24 @@ if (!is_string($documentsPayload)) {
                 return true;
             };
 
-            window.omoOpenDocumentEditorByPayload = function (documentItem) {
-                if (!documentItem || !documentItem.canEdit) {
+            window.omoOpenDocumentEditorByPayload = function (documentItem, rootOverride) {
+                const root = rootOverride instanceof Element
+                    ? rootOverride
+                    : getDocumentsRoot();
+
+                if (!documentItem || !documentItem.canEdit || isPvDocumentBlockedInLocalNavigation(documentItem, root)) {
                     return false;
                 }
 
                 if (String(documentItem.documentType || '').trim().toLowerCase() === 'pv') {
-                    return window.omoOpenDocumentPvPreparationByPayload(documentItem);
+                    return window.omoOpenDocumentPvPreparationByPayload(documentItem, root);
                 }
 
                 if (!documentItem.editUrl) {
                     return false;
                 }
 
-                if (!window.omoPreserveDocumentPvPreparationDrawer()) {
+                if (!useLocalDrawerNavigation(root) && !window.omoPreserveDocumentPvPreparationDrawer()) {
                     window.omoCloseDocumentPvPreparationDrawer({ force: true });
                 }
 
@@ -4595,6 +4672,7 @@ if (!is_string($documentsPayload)) {
                     openInNewWindow: String(trigger.getAttribute('data-omo-document-open-in-new-window') || '').trim() === '1',
                     documentType: String(trigger.getAttribute('data-omo-document-type') || '').trim(),
                     pvPreparationUrl: String(trigger.getAttribute('data-omo-document-pv-editor-url') || '').trim(),
+                    canOpenInPvApplicationTab: String(trigger.getAttribute('data-omo-document-can-open-in-pv-tab') || '').trim() === '1',
                     title: String(trigger.getAttribute('data-omo-document-title') || '').trim(),
                     fullDateLabel: String(trigger.getAttribute('data-omo-document-full-date') || '').trim()
                 };
@@ -4604,6 +4682,11 @@ if (!is_string($documentsPayload)) {
                         return true;
                     }
                     event.preventDefault();
+                }
+
+                const root = trigger.closest('#omo-documents-root') || getDocumentsRoot();
+                if (isPvDocumentBlockedInLocalNavigation(documentPayload, root)) {
+                    return false;
                 }
 
                 if (documentPayload.openInNewWindow && documentPayload.externalUrl !== '') {
@@ -4618,7 +4701,6 @@ if (!is_string($documentsPayload)) {
                     return false;
                 }
 
-                const root = trigger.closest('#omo-documents-root') || getDocumentsRoot();
                 const routeToken = buildDocumentRouteToken(documentId, 'detail');
                 const hashState = typeof window.omoParsePopupHashState === 'function'
                     ? window.omoParsePopupHashState()
@@ -4647,10 +4729,13 @@ if (!is_string($documentsPayload)) {
 
                 const root = getDocumentsRoot();
                 const documentItem = findDocumentPayloadItemById(resolvedDocumentId, root);
+                if (documentItem && isPvDocumentBlockedInLocalNavigation(documentItem, root)) {
+                    return false;
+                }
                 if (
                     documentItem
                     && String(documentItem.documentType || '').trim().toLowerCase() === 'pv'
-                    && window.omoOpenDocumentEditorByPayload(documentItem)
+                    && window.omoOpenDocumentEditorByPayload(documentItem, root)
                 ) {
                     return true;
                 }
@@ -4666,7 +4751,7 @@ if (!is_string($documentsPayload)) {
                     return true;
                 }
 
-                if (documentItem && window.omoOpenDocumentEditorByPayload(documentItem)) {
+                if (documentItem && window.omoOpenDocumentEditorByPayload(documentItem, root)) {
                     return true;
                 }
 
@@ -4896,7 +4981,7 @@ if (!is_string($documentsPayload)) {
                 }
 
                 const documentItem = findDocumentPayloadItemById(documentId);
-                if (documentItem && window.omoOpenDocumentEditorByPayload(documentItem)) {
+                if (documentItem && window.omoOpenDocumentEditorByPayload(documentItem, root)) {
                     return true;
                 }
 

--- a/omo/api/documents/pv/action.php
+++ b/omo/api/documents/pv/action.php
@@ -2,6 +2,7 @@
 require_once dirname(__DIR__, 2) . '/bootstrap.php';
 require_once __DIR__ . '/helpers.php';
 require_once dirname(__DIR__, 2) . '/stats/shared.php';
+require_once dirname(__DIR__, 4) . '/common/notification_center.php';
 
 header('Content-Type: application/json; charset=UTF-8');
 
@@ -257,6 +258,7 @@ function omoDocumentsPvEditorBuildDocumentPayload(\dbObject\Document $document, 
         'isPvTemplate' => $document->isPvTemplate(),
         'canManagePvTemplate' => $document->canUserManagePvDocument($currentUserId)
             && $document->getPvStage() !== \dbObject\Document::PV_STAGE_REVIEW,
+        'associatedEvent' => omoDocumentsPvEditorBuildAssociatedEventPayload($document->getAssociatedEvent()),
     ];
 }
 
@@ -307,6 +309,32 @@ function omoDocumentsPvEditorBuildEventEmbedPayload(\dbObject\Event $event): arr
             trim((string)($locationData['videoUrl'] ?? '')),
         ]))),
         'startAt' => $startAt instanceof \DateTimeInterface ? $startAt->format(DATE_ATOM) : '',
+    ];
+}
+
+function omoDocumentsPvEditorBuildAssociatedEventPayload(?\dbObject\Event $event): ?array
+{
+    if (!($event instanceof \dbObject\Event) || (int)$event->getId() <= 0) {
+        return null;
+    }
+
+    $startAt = $event->get('start_at');
+    $endAt = $event->get('end_at');
+    $scheduleLabel = '';
+    if ($startAt instanceof \DateTimeInterface) {
+        $scheduleLabel = omoDocumentsPvEditorFormatDateTime($startAt);
+        if ($endAt instanceof \DateTimeInterface) {
+            $scheduleLabel .= $startAt->format('Y-m-d') === $endAt->format('Y-m-d')
+                ? ' - ' . $endAt->format('H:i')
+                : ' - ' . omoDocumentsPvEditorFormatDateTime($endAt);
+        }
+    }
+
+    return [
+        'id' => (int)$event->getId(),
+        'scheduleLabel' => $scheduleLabel,
+        'startAt' => $startAt instanceof \DateTimeInterface ? $startAt->format(DATE_ATOM) : '',
+        'endAt' => $endAt instanceof \DateTimeInterface ? $endAt->format(DATE_ATOM) : '',
     ];
 }
 
@@ -580,6 +608,68 @@ if ($action === 'update_document_metadata') {
     $document->load((int)$document->getId());
     omoDocumentsPvEditorJsonResponse([
         'status' => true,
+        'document' => omoDocumentsPvEditorBuildDocumentPayload($document, $organizationId, $currentUserId),
+    ]);
+}
+
+if ($action === 'extend_associated_event') {
+    if (
+        $document->getPvStage() !== \dbObject\Document::PV_STAGE_MEETING
+        || !$document->canUserManagePvDocument($currentUserId)
+        || !omoDocumentsPvEditorHasValidSessionToken($organizationId, $documentId, $currentUserId, $editorToken)
+    ) {
+        omoDocumentsPvEditorJsonResponse([
+            'status' => false,
+            'message' => omoDocumentsPvEditorActionT('documents.pv_editor.error.forbidden'),
+        ], 403);
+    }
+
+    $minutes = isset($_POST['minutes']) ? (int)$_POST['minutes'] : 0;
+    if (!in_array($minutes, [5, 10, 15, 30], true)) {
+        omoDocumentsPvEditorJsonResponse([
+            'status' => false,
+            'message' => omoDocumentsPvEditorActionT('documents.pv_editor.error.invalid_request'),
+        ], 400);
+    }
+
+    $event = $document->getAssociatedEvent();
+    if (
+        !($event instanceof \dbObject\Event)
+        || (int)$event->get('IDorganization') !== $organizationId
+    ) {
+        omoDocumentsPvEditorJsonResponse([
+            'status' => false,
+            'message' => omoDocumentsPvEditorActionT('documents.pv_editor.error.forbidden'),
+        ], 403);
+    }
+
+    $endAt = $event->get('end_at');
+    if (!($endAt instanceof \DateTimeInterface)) {
+        omoDocumentsPvEditorJsonResponse([
+            'status' => false,
+            'message' => omoDocumentsPvEditorActionT('documents.pv_editor.error.invalid_request'),
+        ], 400);
+    }
+
+    $event->set('end_at', \DateTimeImmutable::createFromInterface($endAt)->modify('+' . $minutes . ' minutes'));
+    $saveResult = $event->save();
+    if (!is_array($saveResult) || ($saveResult['status'] ?? false) !== true) {
+        omoDocumentsPvEditorJsonResponse([
+            'status' => false,
+            'message' => trim((string)($saveResult['text'] ?? omoDocumentsPvEditorActionT('documents.pv_editor.error.operation_failed'))),
+        ], 400);
+    }
+
+    try {
+        notificationCenterDispatchEventChange($event, 'schedule', $currentUserId);
+    } catch (\Throwable $exception) {
+        error_log('OMO PV meeting extension notification dispatch failed: ' . $exception->getMessage());
+    }
+
+    $document->load((int)$document->getId());
+    omoDocumentsPvEditorJsonResponse([
+        'status' => true,
+        'event' => omoDocumentsPvEditorBuildAssociatedEventPayload($event),
         'document' => omoDocumentsPvEditorBuildDocumentPayload($document, $organizationId, $currentUserId),
     ]);
 }

--- a/omo/api/documents/pv/editor.php
+++ b/omo/api/documents/pv/editor.php
@@ -46,25 +46,6 @@ $accessGranted = $documentId > 0
 $escape = 'omoApiEscape';
 $uiText = omoDocumentsPvEditorBuildUiText('omoDocumentsPvEditorT');
 
-$formatter = class_exists('IntlDateFormatter')
-    ? new IntlDateFormatter('fr_FR', IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT)
-    : null;
-
-$formatDateTime = static function ($value) use ($formatter): string {
-    if (!$value instanceof DateTimeInterface) {
-        return '';
-    }
-
-    if ($formatter instanceof IntlDateFormatter) {
-        $formatted = $formatter->format($value);
-        if (is_string($formatted) && $formatted !== '') {
-            return $formatted;
-        }
-    }
-
-    return $value->format('d.m.Y H:i');
-};
-
 $formatProjectDate = static function ($value): string {
     return $value instanceof DateTimeInterface ? $value->format('d.m.Y') : '';
 };
@@ -134,6 +115,9 @@ if (!$isPublicParticipation) {
 }
 $isPvReview = $document->getPvStage() === \dbObject\Document::PV_STAGE_REVIEW;
 $canEditPvDocumentHeader = $canManagePvDocument && !$isPvReview;
+$canExtendAssociatedEvent = !$isPublicParticipation
+    && $hasAssociatedEvent
+    && $document->getPvStage() === \dbObject\Document::PV_STAGE_MEETING;
 $canPassPvEditor = $isPvEditor && !$isPvReview;
 $isPvTemplate = $document->isPvTemplate();
 $canCreatePvGroups = !$isPublicParticipation && $document->canUserCreatePvGroups($currentUserId);
@@ -178,11 +162,11 @@ $eventTitle = $hasAssociatedEvent
     : '';
 $eventSchedule = '';
 if ($eventStartAt instanceof DateTimeInterface) {
-    $eventSchedule = $formatDateTime($eventStartAt);
+    $eventSchedule = omoDocumentsPvEditorFormatDateTime($eventStartAt);
     if ($eventEndAt instanceof DateTimeInterface) {
         $eventSchedule .= $eventStartAt->format('Y-m-d') === $eventEndAt->format('Y-m-d')
             ? ' - ' . $eventEndAt->format('H:i')
-            : ' - ' . $formatDateTime($eventEndAt);
+            : ' - ' . omoDocumentsPvEditorFormatDateTime($eventEndAt);
     }
 }
 $eventLocation = implode(' | ', $locationParts);
@@ -404,8 +388,8 @@ if ($hasCalendarApplication) {
         $startAt = $embeddableEvent->get('start_at');
         $endAt = $embeddableEvent->get('end_at');
         $scheduleLabel = trim(
-            ($startAt instanceof DateTimeInterface ? $formatDateTime($startAt) : '')
-            . ($endAt instanceof DateTimeInterface ? ' - ' . $formatDateTime($endAt) : '')
+            ($startAt instanceof DateTimeInterface ? omoDocumentsPvEditorFormatDateTime($startAt) : '')
+            . ($endAt instanceof DateTimeInterface ? ' - ' . omoDocumentsPvEditorFormatDateTime($endAt) : '')
         );
         $locationData = $embeddableEvent->getLocationDisplayData();
         $locationLabel = trim(implode(' | ', array_filter([
@@ -651,7 +635,7 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     }
 
     .omo-pv-editor__application-workspace {
-        grid-column: 1 / -1;
+        grid-column: 3;
         min-width: 0;
         min-height: 0;
         overflow: hidden;
@@ -920,6 +904,29 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     .omo-pv-editor__event-info-item--location .omo-pv-editor__event-info-value {
         color: var(--color-text, #10253a);
         font-weight: 750;
+    }
+
+    .omo-pv-editor__event-extension-menu {
+        position: relative;
+        display: inline-flex;
+        flex: 0 0 auto;
+    }
+
+    .omo-pv-editor__event-extension-toggle {
+        min-width: 26px;
+        width: 26px;
+        height: 26px;
+        padding: 0;
+        border-radius: 999px;
+        font-size: 1.1rem;
+        font-weight: 800;
+    }
+
+    .omo-pv-editor__event-extension-panel {
+        position: absolute;
+        top: calc(100% + 6px);
+        left: 0;
+        z-index: 100;
     }
 
     .omo-pv-editor__page-side {
@@ -2401,7 +2408,8 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
         }
 
         .omo-pv-editor--has-application-tabs > .omo-pv-editor__application-workspace {
-            grid-row: 2 / 4;
+            grid-column: 1;
+            grid-row: 3;
         }
 
         .omo-pv-editor__editable-grid {
@@ -2793,7 +2801,17 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
                     <?php if ($eventSchedule !== ''): ?>
                         <div class="omo-pv-editor__event-info-item omo-pv-editor__event-info-item--schedule">
                             <span class="omo-pv-editor__event-info-icon" aria-hidden="true"><img src="/omo/assets/images/documents/event-schedule.png" alt="" class="black-icon"></span>
-                            <span class="omo-pv-editor__event-info-value"><?= $escape($eventSchedule) ?></span>
+                            <span class="omo-pv-editor__event-info-value" data-omo-pv-event-schedule><?= $escape($eventSchedule) ?></span>
+                            <?php if ($canExtendAssociatedEvent): ?>
+                                <div class="generic-menu omo-pv-editor__event-extension-menu" data-omo-pv-event-extension-menu>
+                                    <button type="button" class="generic-menu-toggle omo-pv-editor__event-extension-toggle" data-omo-pv-event-extension-toggle aria-haspopup="menu" aria-expanded="false" aria-controls="omoPvEventExtensionMenu" aria-label="<?= $escape(omoDocumentsPvEditorT('documents.pv_editor.event.extend.button_title')) ?>" title="<?= $escape(omoDocumentsPvEditorT('documents.pv_editor.event.extend.button_title')) ?>">+</button>
+                                    <div id="omoPvEventExtensionMenu" class="generic-menu-panel generic-menu-panel--wide omo-pv-editor__event-extension-panel" data-omo-pv-event-extension-panel role="menu" aria-label="<?= $escape(omoDocumentsPvEditorT('documents.pv_editor.event.extend.menu_aria')) ?>" hidden>
+                                        <?php foreach ([5, 10, 15, 30] as $extensionMinutes): ?>
+                                            <button type="button" class="generic-menu-item" data-omo-pv-event-extension-minutes="<?= $extensionMinutes ?>" role="menuitem"><?= $escape(omoDocumentsPvEditorT('documents.pv_editor.event.extend.option', ['minutes' => $extensionMinutes])) ?></button>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
+                            <?php endif; ?>
                         </div>
                     <?php endif; ?>
                     <?php if ($eventLocation !== ''): ?>
@@ -2956,6 +2974,10 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     const invitationsMenuToggle = root.querySelector('[data-omo-pv-invitations-menu-toggle]');
     const invitationsMenuPanel = root.querySelector('[data-omo-pv-invitations-menu-panel]');
     const invitationsSendButton = root.querySelector('[data-omo-pv-invitations-send-url]');
+    const eventScheduleValue = root.querySelector('[data-omo-pv-event-schedule]');
+    const eventExtensionMenu = root.querySelector('[data-omo-pv-event-extension-menu]');
+    const eventExtensionToggle = root.querySelector('[data-omo-pv-event-extension-toggle]');
+    const eventExtensionPanel = root.querySelector('[data-omo-pv-event-extension-panel]');
     const documentTitleInput = root.querySelector('[data-omo-pv-document-title]');
     const documentDescriptionInput = root.querySelector('[data-omo-pv-document-description]');
     const documentVisibilitySelect = root.querySelector('[data-omo-pv-document-visibility]');
@@ -2970,7 +2992,7 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     const applicationTabsCsrf = String(root.getAttribute('data-omo-pv-application-tabs-csrf') || '').trim();
     const canManageApplicationTabs = root.getAttribute('data-omo-pv-application-tabs-manage') === '1';
     const applicationContextHolonId = Number(root.getAttribute('data-omo-pv-application-tabs-cid') || 0);
-    const pvEditorSurfaces = [root.querySelector('.omo-pv-editor__sidebar'), root.querySelector('.omo-pv-editor__resizer'), mainPanel].filter(Boolean);
+    const pvEditorSwitchableSurfaces = [mainPanel].filter(Boolean);
     const initialApplicationCatalog = <?= json_encode($pvApplicationCatalog, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
     const initialApplicationTabs = <?= json_encode($pvApplicationTabsPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
     const applicationTabsUi = <?= json_encode([
@@ -3006,8 +3028,8 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     const initialAttendancePayload = <?= json_encode($attendancePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
     const initialPollingRevision = <?= json_encode($pollingRevision, JSON_UNESCAPED_SLASHES) ?>;
     const attendanceEnabled = <?= json_encode($showAttendance) ?>;
-    const eventStartAtIso = <?= json_encode($eventStartAtIso, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
-    const eventEndAtIso = <?= json_encode($eventEndAtIso, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+    let eventStartAtIso = <?= json_encode($eventStartAtIso, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
+    let eventEndAtIso = <?= json_encode($eventEndAtIso, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
     const saveLabel = <?= json_encode(omoDocumentsPvEditorT('documents.pv_editor.action.save'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
     const savingLabel = <?= json_encode(omoDocumentsPvEditorT('documents.pv_editor.action.saving'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
     const savedLabel = <?= json_encode(omoDocumentsPvEditorT('documents.pv_editor.state.saved'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
@@ -3207,6 +3229,7 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
         'documentSaveError' => omoDocumentsPvEditorT('documents.pv_editor.error.document_save'),
         'autoSummaryError' => omoDocumentsPvEditorT('documents.pv_editor.error.auto_summary'),
         'autoSummaryEmpty' => omoDocumentsPvEditorT('documents.pv_editor.error.auto_summary_empty'),
+        'eventExtensionSaving' => omoDocumentsPvEditorT('documents.pv_editor.event.extend.saving'),
         'highlightLabel' => omoDocumentsPvEditorT('documents.pv_editor.toolbar.highlight'),
         'highlightTitle' => omoDocumentsPvEditorT('documents.pv_editor.toolbar.highlight_title'),
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
@@ -3293,7 +3316,7 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
             });
         }
 
-        pvEditorSurfaces.forEach(function (surface) {
+        pvEditorSwitchableSurfaces.forEach(function (surface) {
             surface.hidden = normalizedTabId > 0;
         });
         if (!applicationWorkspace) {
@@ -5655,6 +5678,7 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
         }
 
         currentDocumentPayload = Object.assign({}, currentDocumentPayload, documentPayload);
+        applyAssociatedEventSchedule(currentDocumentPayload.associatedEvent);
         knownDocumentSyncVersion = String(currentDocumentPayload.syncVersion || knownDocumentSyncVersion || '');
         if (currentDocumentPayload.isPvValidated === true) {
             stopPvEditorBackgroundWork();
@@ -5773,6 +5797,26 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
         }
 
         return Math.max(0, Math.round(numericMinutes)) + "'";
+    }
+
+    function applyAssociatedEventSchedule(eventPayload) {
+        if (!eventPayload || typeof eventPayload !== 'object') {
+            return;
+        }
+
+        const startAt = String(eventPayload.startAt || '').trim();
+        const endAt = String(eventPayload.endAt || '').trim();
+        if (startAt !== '') {
+            eventStartAtIso = startAt;
+        }
+        if (endAt !== '') {
+            eventEndAtIso = endAt;
+        }
+
+        const scheduleLabel = String(eventPayload.scheduleLabel || '').trim();
+        if (eventScheduleValue instanceof Element && scheduleLabel !== '') {
+            eventScheduleValue.textContent = scheduleLabel;
+        }
     }
 
     function getMeetingDurationMinutes() {
@@ -8460,6 +8504,63 @@ $isPvReviewDiscussion = $pvStage === \dbObject\Document::PV_STAGE_REVIEW;
     if (documentVisibilitySelect instanceof Element) {
         documentVisibilitySelect.addEventListener('change', function () {
             markDocumentMetadataDirty();
+        });
+    }
+    function closeEventExtensionMenu() {
+        if (eventExtensionPanel instanceof HTMLElement) {
+            eventExtensionPanel.hidden = true;
+        }
+        if (eventExtensionToggle instanceof HTMLButtonElement) {
+            eventExtensionToggle.setAttribute('aria-expanded', 'false');
+        }
+    }
+    if (eventExtensionToggle instanceof HTMLButtonElement && eventExtensionPanel instanceof HTMLElement) {
+        eventExtensionToggle.addEventListener('click', function () {
+            const willOpen = eventExtensionPanel.hidden;
+            eventExtensionPanel.hidden = !willOpen;
+            eventExtensionToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        });
+        document.addEventListener('pointerdown', function (event) {
+            if (eventExtensionMenu instanceof HTMLElement && !eventExtensionMenu.contains(event.target)) {
+                closeEventExtensionMenu();
+            }
+        }, true);
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                closeEventExtensionMenu();
+            }
+        });
+        eventExtensionPanel.querySelectorAll('[data-omo-pv-event-extension-minutes]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                const minutes = Number(button.getAttribute('data-omo-pv-event-extension-minutes') || 0);
+                if (![5, 10, 15, 30].includes(minutes)) {
+                    return;
+                }
+
+                const menuButtons = Array.from(eventExtensionPanel.querySelectorAll('[data-omo-pv-event-extension-minutes]'));
+                const originalLabel = button.textContent;
+                menuButtons.forEach(function (menuButton) { menuButton.disabled = true; });
+                button.textContent = editorClientUi.eventExtensionSaving || originalLabel;
+                closeEventExtensionMenu();
+
+                postPointAction('extend_associated_event', 0, {minutes: minutes})
+                    .then(function (payload) {
+                        applyAssociatedEventSchedule(payload && payload.event ? payload.event : null);
+                        if (payload && payload.document) {
+                            mergeCurrentDocumentPayload(payload.document);
+                        }
+                        renderTimingSummary();
+                    })
+                    .catch(function (error) {
+                        if (window.alert) {
+                            window.alert(String(error && error.message || editorClientUi.genericError || ''));
+                        }
+                    })
+                    .finally(function () {
+                        button.textContent = originalLabel;
+                        menuButtons.forEach(function (menuButton) { menuButton.disabled = false; });
+                    });
+            });
         });
     }
     if (invitationsButton instanceof HTMLButtonElement) {

--- a/omo/api/documents/pv/helpers.php
+++ b/omo/api/documents/pv/helpers.php
@@ -236,6 +236,10 @@ function omoDocumentsPvEditorSourceLang(): array
         'documents.pv_editor.notice.schedule' => ['text' => 'Réunion prévue le {date}.', 'context' => 'Schedule sentence shown in the PV editor header.'],
         'documents.pv_editor.notice.event' => ['text' => 'Événement associé', 'context' => 'Label used in the PV editor header for the linked event.'],
         'documents.pv_editor.notice.location' => ['text' => 'Lieu', 'context' => 'Label used in the PV editor header for the event location.'],
+        'documents.pv_editor.event.extend.button_title' => ['text' => 'Prolonger la réunion', 'context' => 'Tooltip for the button that extends the associated meeting schedule from the PV editor.'],
+        'documents.pv_editor.event.extend.menu_aria' => ['text' => 'Options de prolongation de la réunion', 'context' => 'Accessible label for the menu that extends the associated meeting schedule from the PV editor.'],
+        'documents.pv_editor.event.extend.option' => ['text' => 'Ajouter {minutes} minutes', 'context' => 'Menu option that extends the associated meeting end time by a number of minutes.'],
+        'documents.pv_editor.event.extend.saving' => ['text' => 'Prolongation…', 'context' => 'Temporary menu option label while the associated meeting is being extended.'],
         'documents.pv_editor.notice.reorder' => ['text' => 'Reordonner les points', 'context' => 'Title for the PV point reorder handle.'],
         'documents.pv_editor.notice.move_up' => ['text' => 'Monter', 'context' => 'Title for the touch-friendly move up button.'],
         'documents.pv_editor.notice.move_down' => ['text' => 'Descendre', 'context' => 'Title for the touch-friendly move down button.'],
@@ -256,6 +260,25 @@ function omoDocumentsPvEditorSourceLang(): array
         'documents.pv_editor.summary.overrun' => ['text' => 'Dépassement', 'context' => 'Legend label for overrun beyond meeting duration in the PV editor chart.'],
         'documents.pv_editor.summary.not_started' => ['text' => '--', 'context' => 'Fallback value for remaining time when the meeting is not in progress.'],
     ];
+}
+
+function omoDocumentsPvEditorFormatDateTime($value): string
+{
+    if (!$value instanceof \DateTimeInterface) {
+        return '';
+    }
+
+    $formatter = class_exists('IntlDateFormatter')
+        ? new \IntlDateFormatter('fr_FR', \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT)
+        : null;
+    if ($formatter instanceof \IntlDateFormatter) {
+        $formatted = $formatter->format($value);
+        if (is_string($formatted) && $formatted !== '') {
+            return $formatted;
+        }
+    }
+
+    return $value->format('d.m.Y H:i');
 }
 
 function omoDocumentsPvEditorBuildIndicatorEmbedPayload(\dbObject\StatIndicator $indicator, bool $isPvEditor = false, ?callable $translate = null): array

--- a/omo/assets/css/styles.css
+++ b/omo/assets/css/styles.css
@@ -3146,7 +3146,7 @@ html[data-theme] .common-help-card p {
 }
 
 .omo-overlay-drawer--detail-panel > .omo-overlay-drawer__panel {
-    width: min(880px, 94vw);
+    width: min(880px, 94vw, 100%);
     transform: translateX(100%);
     transition: opacity 0.2s ease, transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
     will-change: transform, opacity;

--- a/omo/assets/js/app.js
+++ b/omo/assets/js/app.js
@@ -1035,6 +1035,7 @@ function loadContent(target, url, type = 'panel', onLoaded = null) {
             });
 
             $target.html(temp.innerHTML);
+            omoPreparePvApplicationSubdrawers($target.get(0));
             omoInitMobileHeaderMenus($target.get(0));
             omoExecuteFetchedScripts(scriptSource, $target.get(0));
             omoInitMobileHeaderMenus($target.get(0));
@@ -5540,6 +5541,20 @@ function omoIsPvApplicationTabContext(element = null) {
         && candidate.closest('[data-omo-pv-application-panel]') !== null;
 }
 
+function omoPreparePvApplicationSubdrawers(scope) {
+    const container = scope && scope.jquery ? scope.get(0) : scope;
+    if (!(container instanceof Element) || !omoIsPvApplicationTabContext(container)) {
+        return;
+    }
+
+    const drawers = container.matches('.omo-overlay-drawer')
+        ? [container]
+        : Array.from(container.querySelectorAll('.omo-overlay-drawer'));
+    drawers.forEach(function (drawer) {
+        drawer.classList.add('omo-overlay-drawer--detail-panel');
+    });
+}
+
 function omoExecuteFetchedScripts(container, loadTarget = null) {
     if (!container) {
         return;
@@ -5660,6 +5675,7 @@ function omoReplaceFetchedPanelRoot(options = {}) {
             }
 
             currentRoot.parentNode.replaceChild(nextRoot, currentRoot);
+            omoPreparePvApplicationSubdrawers(nextRoot);
             omoInitMobileHeaderMenus(nextRoot);
             omoExecuteFetchedScripts(scriptSource, nextRoot);
             omoInitMobileHeaderMenus(nextRoot);
@@ -5785,6 +5801,7 @@ window.omoOpenUserContextPopup = omoOpenUserContextPopup;
 window.omoReplaceFetchedPanelRoot = omoReplaceFetchedPanelRoot;
 window.omoFindApplicationRoot = omoFindApplicationRoot;
 window.omoIsPvApplicationTabContext = omoIsPvApplicationTabContext;
+window.omoPreparePvApplicationSubdrawers = omoPreparePvApplicationSubdrawers;
 window.omoLoadContent = loadContent;
 window.omoSetPanelResultsLoadingSkeleton = omoSetPanelResultsLoadingSkeleton;
 window.omoRunRuntimeMaintenance = omoRunRuntimeMaintenance;

--- a/omo/document_share.php
+++ b/omo/document_share.php
@@ -121,7 +121,7 @@ $documentDescription = trim((string)($livePayload['description'] ?? ''));
     <script src="/shared_functions.js"></script>
     <script>sharedApplyDocumentTheme();</script>
     <link rel="stylesheet" href="/common/assets/components.css">
-    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-subdrawer-slide">
+    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-all-subdrawers">
     <style>
     body {
         margin: 0;

--- a/omo/index.php
+++ b/omo/index.php
@@ -777,7 +777,7 @@ if ($isOrganizationHub && !$isDemoGuest) {
     <?= $omoThemeBootstrapHtml . PHP_EOL ?>
     <title><?= htmlspecialchars(t('app.directory.page_title')) ?></title>
     <?= $omoPwaHeadHtml . PHP_EOL ?>
-<link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-subdrawer-slide">
+<link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-all-subdrawers">
     <link rel="stylesheet" href="/common/assets/auth.css">
 </head>
 <body class="auth-state-page auth-state-page--scrollable auth-state-page--themed auth-state-page--with-topbar">
@@ -1472,7 +1472,7 @@ if (!$isDemoGuest && $currentUserId > 0 && patreonSupportUiIsEnabled()) {
     <title><?= htmlspecialchars(t('app.main.page_title', ['organizationName' => (($organizationContext['name'] ?? '') ?: 'OMO')])) ?></title>
     <?= $omoThemeBootstrapHtml . PHP_EOL ?>
     <?= $omoPwaHeadHtml . PHP_EOL ?>
-<link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-subdrawer-slide">
+<link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-all-subdrawers">
     <style>
         html[data-omo-organization-accent] {
             --omo-organization-accent: <?= $omoOrganizationAccentColorCss ?>;
@@ -1645,7 +1645,7 @@ window.omoConfig = <?=
 <script src="/omo/assets/js/site-update.js"></script>
 <?php } ?>
 <script src="assets/js/simple-html-field.js?v=20260904-highlight-clear"></script>
-<script src="assets/js/app.js?v=20260906-pv-local-subdrawers"></script>
+<script src="assets/js/app.js?v=20260906-pv-all-subdrawers"></script>
 <script src="assets/js/structure-mini-map.js?v=20260826-structure-data-cache"></script>
 
 <script>

--- a/omo/pv_participation.php
+++ b/omo/pv_participation.php
@@ -72,7 +72,7 @@ require_once __DIR__ . '/api/bootstrap.php';
     <script>sharedApplyDocumentTheme();</script>
     <link rel="stylesheet" href="/common/assets/components.css">
     <link rel="stylesheet" href="/common/assets/topbar.css">
-    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-subdrawer-slide">
+    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-all-subdrawers">
     <style>
     html, body { height: 100%; margin: 0; }
     body { background: var(--color-bg, #f8fafc); color: var(--color-text, #1f2937); }

--- a/omo/share.php
+++ b/omo/share.php
@@ -157,7 +157,7 @@ $brandHref = $shareLink->buildShareUrl($initialCid);
     <script src="/shared_functions.js"></script>
     <script>sharedApplyDocumentTheme();</script>
     <link rel="stylesheet" href="/common/assets/omo_public_pages.css">
-    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-subdrawer-slide">
+    <link rel="stylesheet" href="/omo/assets/css/styles.css?v=20260906-pv-all-subdrawers">
     <base href="/omo/">
     <style>
     :root {
@@ -295,7 +295,7 @@ window.omoConfig = <?= json_encode(array(
     'shareAllowsPeopleDetail' => $shareLink->allowsPeopleDetail(),
 ), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?>;
 </script>
-<script src="/omo/assets/js/app.js?v=20260906-pv-local-subdrawers"></script>
+<script src="/omo/assets/js/app.js?v=20260906-pv-all-subdrawers"></script>
 <script src="/omo/assets/js/structure-mini-map.js"></script>
 <script>
 $(document).ready(function () {

--- a/tests/pv_application_subdrawers_test.js
+++ b/tests/pv_application_subdrawers_test.js
@@ -22,6 +22,16 @@ assert(
   appSource.includes('window.omoIsPvApplicationTabContext = omoIsPvApplicationTabContext;'),
   'PV application context detection must be available to embedded applications.'
 );
+assert(
+  appSource.includes('function omoPreparePvApplicationSubdrawers')
+    && appSource.includes("drawer.classList.add('omo-overlay-drawer--detail-panel');"),
+  'Every internal drawer loaded by a PV application tab must receive the bounded detail-panel style.'
+);
+assert(
+  appSource.includes('omoPreparePvApplicationSubdrawers($target.get(0));')
+    && appSource.includes('omoPreparePvApplicationSubdrawers(nextRoot);'),
+  'PV subdrawers must remain bounded after both initial loads and application view refreshes.'
+);
 
 const stylesSource = read('omo/assets/css/styles.css');
 assert(
@@ -43,6 +53,10 @@ assert(
 assert(
   stylesSource.includes('.omo-overlay-drawer--detail-panel > .omo-overlay-drawer__panel'),
   'Application detail drawers must use the shared bounded side-panel style.'
+);
+assert(
+  stylesSource.includes('width: min(880px, 94vw, 100%);'),
+  'Application detail drawers must never exceed their PV application column.'
 );
 assert(
   stylesSource.includes('transform: translateX(100%);'),
@@ -79,8 +93,36 @@ assert(
   'Documents must detect local PV drawer navigation.'
 );
 assert(
+  documentsSource.includes("detailDrawerController && typeof detailDrawerController.open === 'function'"),
+  'Document details must use the shared animated subdrawer opener when available.'
+);
+assert(
+  documentsSource.includes("!empty($applicationViewPreferences['isPvApplicationTab']) ? ' omo-overlay-drawer--detail-panel' : ''"),
+  'The Documents application must render its bounded drawer class server-side in a PV tab.'
+);
+assert(
+  documentsSource.includes('if (useLocalDrawerNavigation(documentsRoot))')
+    && documentsSource.includes('window.omoOpenDocumentPvPreparationByPayload = function (documentItem, rootOverride)'),
+  'The Documents meeting tab must never launch another PV preparation top sheet.'
+);
+assert(
   documentsSource.includes('!useLocalDrawerNavigation(root) && routeToken'),
   'Document details must bypass global hash navigation inside a PV tab.'
+);
+assert(
+  documentsSource.includes("'canOpenInPvApplicationTab' => $canOpenInPvApplicationTab")
+    && documentsSource.includes('function isPvDocumentBlockedInLocalNavigation(documentItem, rootOverride)')
+    && documentsSource.includes('data-omo-document-can-open-in-pv-tab'),
+  'The Documents meeting tab must expose and enforce whether a PV is validated before opening it.'
+);
+assert(
+  documentsSource.includes('isPvDocumentBlockedInLocalNavigation(documentPayload, root)')
+    && documentsSource.includes('documentItem.canOpenInPvApplicationTab !== true'),
+  'Unvalidated PV documents must be blocked before detail, keyboard, or editor navigation can replace the meeting drawer.'
+);
+assert(
+  documentsSource.includes('if (!useLocalDrawerNavigation(root) && !window.omoPreserveDocumentPvPreparationDrawer())'),
+  'Opening a document locally must not collapse or close the persistent meeting drawer.'
 );
 
 const documentEditorSource = read('omo/api/documents/create.php');

--- a/tests/pv_application_tabs_test.php
+++ b/tests/pv_application_tabs_test.php
@@ -53,6 +53,9 @@ assertPvApplicationTabs(strpos($editorSource, 'data-omo-pv-application-tab-remov
 assertPvApplicationTabs(strpos($editorSource, 'Promise.allSettled(operations)') !== false, 'The application picker must reconcile additions and removals safely.');
 assertPvApplicationTabs(strpos($editorSource, '/omo/assets/images/documents/pv.png') !== false, 'The PV tab must display the document PV icon.');
 assertPvApplicationTabs(strpos($editorSource, '--param-tabs-tab-background-active') !== false, 'Active application tabs must have a visible colored state.');
+assertPvApplicationTabs(strpos($editorSource, ".omo-pv-editor__application-workspace {\n        grid-column: 3;") !== false, 'Application tabs must render in the right-hand editor column.');
+assertPvApplicationTabs(strpos($editorSource, 'const pvEditorSwitchableSurfaces = [mainPanel].filter(Boolean);') !== false, 'Application tabs must only replace the main PV panel.');
+assertPvApplicationTabs(strpos($editorSource, "root.querySelector('.omo-pv-editor__sidebar'), root.querySelector('.omo-pv-editor__resizer'), mainPanel") === false, 'Application tabs must keep the agenda, timer, and resizer visible.');
 
 $viewPreferencesSource = (string)file_get_contents(dirname(__DIR__) . '/common/application_view_preferences.php');
 assertPvApplicationTabs(strpos($viewPreferencesSource, "\$_GET['pv_application_tab_id']") !== false, 'Application pages must resolve their PV-specific database view.');

--- a/tests/pv_event_extension_test.php
+++ b/tests/pv_event_extension_test.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+function assertPvEventExtension(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$editorSource = (string)file_get_contents(dirname(__DIR__) . '/omo/api/documents/pv/editor.php');
+assertPvEventExtension(
+    strpos($editorSource, 'data-omo-pv-event-extension-minutes') !== false,
+    'The PV editor must expose meeting extension menu choices.'
+);
+assertPvEventExtension(
+    strpos($editorSource, "postPointAction('extend_associated_event'") !== false,
+    'The PV editor must save a selected meeting extension through its action endpoint.'
+);
+assertPvEventExtension(
+    strpos($editorSource, 'applyAssociatedEventSchedule') !== false,
+    'The PV editor must refresh its timer from an updated associated event schedule.'
+);
+
+$actionSource = (string)file_get_contents(dirname(__DIR__) . '/omo/api/documents/pv/action.php');
+assertPvEventExtension(
+    strpos($actionSource, "if (\$action === 'extend_associated_event')") !== false,
+    'The PV action endpoint must handle meeting extensions.'
+);
+assertPvEventExtension(
+    strpos($actionSource, 'in_array($minutes, [5, 10, 15, 30], true)') !== false,
+    'The PV action endpoint must only accept the supported extension durations.'
+);
+assertPvEventExtension(
+    strpos($actionSource, '$document->canUserManagePvDocument($currentUserId)') !== false,
+    'The PV action endpoint must verify that the current person manages the meeting PV.'
+);
+assertPvEventExtension(
+    strpos($actionSource, "notificationCenterDispatchEventChange(\$event, 'schedule', \$currentUserId)") !== false,
+    'Meeting extensions must use the standard schedule-change notification flow.'
+);
+
+$eventSource = (string)file_get_contents(dirname(__DIR__) . '/class/dbobject/event.class.php');
+assertPvEventExtension(
+    strpos($eventSource, "\$document->set('datemodification', new \\DateTimeImmutable());") !== false,
+    'Saving an updated event schedule must refresh the associated PV revision.'
+);
+
+echo "pv_event_extension_test: OK\n";


### PR DESCRIPTION
…ed meeting schedules

- Introduced a new action `extend_associated_event` in `action.php` to handle the extension of associated events by a specified number of minutes.
- Added a new helper function `omoDocumentsPvEditorBuildAssociatedEventPayload` to format the associated event data for the editor.
- Updated the editor UI to include a button for extending the meeting schedule with options for 5, 10, 15, or 30 minutes.
- Enhanced the JavaScript to manage the event extension menu and handle user interactions for extending the event duration.
- Updated styles to accommodate the new event extension UI elements.
- Added tests to ensure the new functionality works as expected and integrates correctly with existing components.